### PR TITLE
Drop kirigami-addons

### DIFF
--- a/io.github.ebonjaeger.bluejay.json
+++ b/io.github.ebonjaeger.bluejay.json
@@ -15,27 +15,6 @@
     ],
     "modules": [
         {
-            "name": "kirigami-addons",
-            "config-opts": [
-                "-DBUILD_TESTING=OFF",
-                "-DCMAKE_BUILD_TYPE=Release"
-            ],
-            "buildsystem": "cmake-ninja",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://download.kde.org/stable/kirigami-addons/kirigami-addons-1.11.0.tar.xz",
-                    "sha256": "6dcdfa324f710f00887e6321212fc8582a3c4712450d129d91435bb1edd8d523",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 242933,
-                        "stable-only": true,
-                        "url-template": "https://download.kde.org/stable/kirigami-addons/kirigami-addons-$version.tar.xz"
-                    }
-                }
-            ]
-        },
-        {
             "name": "bluejay",
             "buildsystem": "cmake-ninja",
             "builddir": true,


### PR DESCRIPTION
Already provided by the runtime version 6.10

Fixes: https://github.com/flathub/io.github.ebonjaeger.bluejay/issues/9